### PR TITLE
Pool buffers for quoted strings and byte slices

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: go
 sudo: false
 go:
-  - 1.2
   - 1.3
   - 1.4
   - 1.5


### PR DESCRIPTION
This reduces allocations when writing multiple quoted
strings or byte slices, by reusing bytes.Buffers, giving
a nice little speed up.

```
name            old time/op    new time/op    delta
EncodeKeyval-8     635ns ± 2%     593ns ± 0%   -6.52%  (p=0.008 n=5+5)

name            old alloc/op   new alloc/op   delta
EncodeKeyval-8      176B ± 0%       64B ± 0%  -63.64%  (p=0.008 n=5+5)

name            old allocs/op  new allocs/op  delta
EncodeKeyval-8      5.00 ± 0%      4.00 ± 0%  -20.00%  (p=0.008 n=5+5)
```