### PR TITLE
Fuzz fix, quote invalid UTF-8 values

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -68,6 +68,8 @@ func (dec *Decoder) ScanKeyval() bool {
 	return false
 
 key:
+	const invalidKeyError = "invalid key"
+
 	start := dec.pos
 	for p, c := range line[dec.pos:] {
 		switch {
@@ -75,6 +77,10 @@ key:
 			dec.pos += p
 			if dec.pos > start {
 				dec.key = line[start:dec.pos]
+				if invalidKey(dec.key) {
+					dec.syntaxError(invalidKeyError)
+					return false
+				}
 			}
 			if dec.key == nil {
 				dec.unexpectedByte(c)
@@ -89,6 +95,10 @@ key:
 			dec.pos += p
 			if dec.pos > start {
 				dec.key = line[start:dec.pos]
+				if invalidKey(dec.key) {
+					dec.syntaxError(invalidKeyError)
+					return false
+				}
 			}
 			return true
 		}
@@ -96,6 +106,10 @@ key:
 	dec.pos = len(line)
 	if dec.pos > start {
 		dec.key = line[start:dec.pos]
+		if invalidKey(dec.key) {
+			dec.syntaxError(invalidKeyError)
+			return false
+		}
 	}
 	return true
 

--- a/decode_test.go
+++ b/decode_test.go
@@ -120,6 +120,7 @@ func TestDecoder_errors(t *testing.T) {
 		{"a=\"\\u1\"", &SyntaxError{Msg: "invalid quoted value", Line: 1, Pos: 8}},
 		{"a\ufffd=bar", &SyntaxError{Msg: "invalid key", Line: 1, Pos: 5}},
 		{"\x80=bar", &SyntaxError{Msg: "invalid key", Line: 1, Pos: 2}},
+		{"\x80", &SyntaxError{Msg: "invalid key", Line: 1, Pos: 2}},
 	}
 
 	for _, test := range tests {

--- a/decode_test.go
+++ b/decode_test.go
@@ -118,6 +118,8 @@ func TestDecoder_errors(t *testing.T) {
 		{"a=\"1\\", &SyntaxError{Msg: "unterminated quoted value", Line: 1, Pos: 6}},
 		{"a=\"\\t1", &SyntaxError{Msg: "unterminated quoted value", Line: 1, Pos: 7}},
 		{"a=\"\\u1\"", &SyntaxError{Msg: "invalid quoted value", Line: 1, Pos: 8}},
+		{"a\ufffd=bar", &SyntaxError{Msg: "invalid key", Line: 1, Pos: 5}},
+		{"\x80=bar", &SyntaxError{Msg: "invalid key", Line: 1, Pos: 2}},
 	}
 
 	for _, test := range tests {

--- a/encode.go
+++ b/encode.go
@@ -170,11 +170,11 @@ func invalidKeyRune(r rune) bool {
 }
 
 func invalidKeyString(key string) bool {
-	return len(key) == 0 || strings.IndexFunc(key, invalidKeyRune) != -1 || !utf8.ValidString(key)
+	return len(key) == 0 || strings.IndexFunc(key, invalidKeyRune) != -1
 }
 
 func invalidKey(key []byte) bool {
-	return len(key) == 0 || bytes.IndexFunc(key, invalidKeyRune) != -1 || !utf8.Valid(key)
+	return len(key) == 0 || bytes.IndexFunc(key, invalidKeyRune) != -1
 }
 
 func writeStringKey(w io.Writer, key string) error {
@@ -239,7 +239,7 @@ func writeStringValue(w io.Writer, value string, ok bool) error {
 	var err error
 	if ok && value == "null" {
 		_, err = io.WriteString(w, `"null"`)
-	} else if strings.IndexFunc(value, needsQuotedValueRune) != -1 || !utf8.ValidString(value) {
+	} else if strings.IndexFunc(value, needsQuotedValueRune) != -1 {
 		_, err = writeQuotedString(w, value)
 	} else {
 		_, err = io.WriteString(w, value)
@@ -249,7 +249,7 @@ func writeStringValue(w io.Writer, value string, ok bool) error {
 
 func writeBytesValue(w io.Writer, value []byte) error {
 	var err error
-	if bytes.IndexFunc(value, needsQuotedValueRune) >= 0 || !utf8.Valid(value) {
+	if bytes.IndexFunc(value, needsQuotedValueRune) != -1 {
 		_, err = writeQuotedBytes(w, value)
 	} else {
 		_, err = w.Write(value)

--- a/encode.go
+++ b/encode.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"reflect"
 	"strings"
+	"unicode/utf8"
 )
 
 // MarshalKeyvals returns the logfmt encoding of keyvals, a variadic sequence
@@ -165,11 +166,19 @@ func writeKey(w io.Writer, key interface{}) error {
 }
 
 func invalidKeyRune(r rune) bool {
-	return r <= ' ' || r == '=' || r == '"'
+	return r <= ' ' || r == '=' || r == '"' || r == utf8.RuneError
+}
+
+func invalidKeyString(key string) bool {
+	return len(key) == 0 || strings.IndexFunc(key, invalidKeyRune) != -1 || !utf8.ValidString(key)
+}
+
+func invalidKey(key []byte) bool {
+	return len(key) == 0 || bytes.IndexFunc(key, invalidKeyRune) != -1 || !utf8.Valid(key)
 }
 
 func writeStringKey(w io.Writer, key string) error {
-	if len(key) == 0 || strings.IndexFunc(key, invalidKeyRune) != -1 {
+	if invalidKeyString(key) {
 		return ErrInvalidKey
 	}
 	_, err := io.WriteString(w, key)
@@ -177,7 +186,7 @@ func writeStringKey(w io.Writer, key string) error {
 }
 
 func writeBytesKey(w io.Writer, key []byte) error {
-	if len(key) == 0 || bytes.IndexFunc(key, invalidKeyRune) != -1 {
+	if invalidKey(key) {
 		return ErrInvalidKey
 	}
 	_, err := w.Write(key)
@@ -223,14 +232,14 @@ func writeValue(w io.Writer, value interface{}) error {
 }
 
 func needsQuotedValueRune(r rune) bool {
-	return r <= ' ' || r == '=' || r == '"'
+	return r <= ' ' || r == '=' || r == '"' || r == utf8.RuneError
 }
 
 func writeStringValue(w io.Writer, value string, ok bool) error {
 	var err error
 	if ok && value == "null" {
 		_, err = io.WriteString(w, `"null"`)
-	} else if strings.IndexFunc(value, needsQuotedValueRune) != -1 {
+	} else if strings.IndexFunc(value, needsQuotedValueRune) != -1 || !utf8.ValidString(value) {
 		_, err = writeQuotedString(w, value)
 	} else {
 		_, err = io.WriteString(w, value)
@@ -240,7 +249,7 @@ func writeStringValue(w io.Writer, value string, ok bool) error {
 
 func writeBytesValue(w io.Writer, value []byte) error {
 	var err error
-	if bytes.IndexFunc(value, needsQuotedValueRune) >= 0 {
+	if bytes.IndexFunc(value, needsQuotedValueRune) >= 0 || !utf8.Valid(value) {
 		_, err = writeQuotedBytes(w, value)
 	} else {
 		_, err = w.Write(value)

--- a/encode_test.go
+++ b/encode_test.go
@@ -125,8 +125,8 @@ func TestMarshalKeyvals(t *testing.T) {
 		if err != d.err {
 			t.Errorf("%#v: got error: %v, want error: %v", d.in, err, d.err)
 		}
-		if got, want := got, d.want; !reflect.DeepEqual(got, want) {
-			t.Errorf("%#v: got '%s', want '%s'", d.in, got, want)
+		if !reflect.DeepEqual(got, d.want) {
+			t.Errorf("%#v: got '%s', want '%s'", d.in, got, d.want)
 		}
 	}
 }
@@ -181,12 +181,12 @@ func (t marshalerStringer) String() string {
 	return fmt.Sprint(t.a + t.b)
 }
 
-var marshalError = errors.New("marshal error")
+var errMarshal = errors.New("marshal error")
 
 type errorMarshaler struct{}
 
 func (errorMarshaler) MarshalText() ([]byte, error) {
-	return nil, marshalError
+	return nil, errMarshal
 }
 
 func BenchmarkEncodeKeyval(b *testing.B) {

--- a/encode_test.go
+++ b/encode_test.go
@@ -53,11 +53,11 @@ func TestEncodeKeyval(t *testing.T) {
 		{key: decimalStringer{5, 9}, value: "v", want: "5.9=v"},
 		{key: (*decimalStringer)(nil), value: "v", err: logfmt.ErrNilKey},
 		{key: marshalerStringer{5, 9}, value: "v", want: "5.9=v"},
-		{key: "k", value: "\xbd", want: "k=\"\\ufffd\""},
-		{key: "k", value: "\ufffd\x00", want: "k=\"\\ufffd\\u0000\""},
-		{key: "k", value: "\ufffd", want: "k=\"\\ufffd\""},
-		{key: "k", value: []byte("\ufffd\x00"), want: "k=\"\\ufffd\\u0000\""},
-		{key: "k", value: []byte("\ufffd"), want: "k=\"\\ufffd\""},
+		{key: "k", value: "\xbd", want: `k="\ufffd"`},
+		{key: "k", value: "\ufffd\x00", want: `k="\ufffd\u0000"`},
+		{key: "k", value: "\ufffd", want: `k="\ufffd"`},
+		{key: "k", value: []byte("\ufffd\x00"), want: `k="\ufffd\u0000"`},
+		{key: "k", value: []byte("\ufffd"), want: `k="\ufffd"`},
 	}
 
 	for _, d := range data {

--- a/encode_test.go
+++ b/encode_test.go
@@ -53,6 +53,11 @@ func TestEncodeKeyval(t *testing.T) {
 		{key: decimalStringer{5, 9}, value: "v", want: "5.9=v"},
 		{key: (*decimalStringer)(nil), value: "v", err: logfmt.ErrNilKey},
 		{key: marshalerStringer{5, 9}, value: "v", want: "5.9=v"},
+		{key: "k", value: "\xbd", want: "k=\"\\ufffd\""},
+		{key: "k", value: "\ufffd\x00", want: "k=\"\\ufffd\\u0000\""},
+		{key: "k", value: "\ufffd", want: "k=\"\\ufffd\""},
+		{key: "k", value: []byte("\ufffd\x00"), want: "k=\"\\ufffd\\u0000\""},
+		{key: "k", value: []byte("\ufffd"), want: "k=\"\\ufffd\""},
 	}
 
 	for _, d := range data {
@@ -82,6 +87,8 @@ func TestMarshalKeyvals(t *testing.T) {
 		{in: kv(), want: nil},
 		{in: kv(nil, "v"), err: logfmt.ErrNilKey},
 		{in: kv(nilPtr, "v"), err: logfmt.ErrNilKey},
+		{in: kv("\ufffd"), err: logfmt.ErrInvalidKey},
+		{in: kv("\xbd"), err: logfmt.ErrInvalidKey},
 		{in: kv("k"), want: []byte("k=null")},
 		{in: kv("k", nil), want: []byte("k=null")},
 		{in: kv("k", ""), want: []byte("k=")},

--- a/fuzz.go
+++ b/fuzz.go
@@ -22,7 +22,7 @@ func Fuzz(data []byte) int {
 	if err = write(parsed, &w1); err != nil {
 		panic(err)
 	}
-	parsed, err = parse(data)
+	parsed, err = parse(w1.Bytes())
 	if err != nil {
 		panic(err)
 	}

--- a/fuzz.go
+++ b/fuzz.go
@@ -12,13 +12,14 @@ import (
 	kr "github.com/kr/logfmt"
 )
 
+// Fuzz checks reserialized data matches
 func Fuzz(data []byte) int {
 	parsed, err := parse(data)
 	if err != nil {
 		return 0
 	}
 	var w1 bytes.Buffer
-	if err := write(parsed, &w1); err != nil {
+	if err = write(parsed, &w1); err != nil {
 		panic(err)
 	}
 	parsed, err = parse(data)
@@ -26,7 +27,7 @@ func Fuzz(data []byte) int {
 		panic(err)
 	}
 	var w2 bytes.Buffer
-	if err := write(parsed, &w2); err != nil {
+	if err = write(parsed, &w2); err != nil {
 		panic(err)
 	}
 	if !bytes.Equal(w1.Bytes(), w2.Bytes()) {
@@ -35,6 +36,7 @@ func Fuzz(data []byte) int {
 	return 1
 }
 
+// FuzzVsKR checks go-logfmt/logfmt against kr/logfmt
 func FuzzVsKR(data []byte) int {
 	parsed, err := parse(data)
 	parsedKR, errKR := parseKR(data)

--- a/fuzz.go
+++ b/fuzz.go
@@ -73,7 +73,6 @@ func parse(data []byte) ([][]kv, error) {
 			kvs = append(kvs, kv{dec.Key(), dec.Value()})
 		}
 		got = append(got, kvs)
-		kvs = nil
 	}
 	return got, dec.Err()
 }

--- a/jsonstring.go
+++ b/jsonstring.go
@@ -71,7 +71,7 @@ func writeQuotedString(w io.Writer, s string) (int, error) {
 			continue
 		}
 		c, size := utf8.DecodeRuneInString(s[i:])
-		if c == utf8.RuneError && size == 1 {
+		if c == utf8.RuneError {
 			if start < i {
 				buf.WriteString(s[start:i])
 			}
@@ -129,7 +129,7 @@ func writeQuotedBytes(w io.Writer, s []byte) (int, error) {
 			continue
 		}
 		c, size := utf8.DecodeRune(s[i:])
-		if c == utf8.RuneError && size == 1 {
+		if c == utf8.RuneError {
 			if start < i {
 				buf.Write(s[start:i])
 			}
@@ -182,7 +182,7 @@ func unquoteBytes(s []byte) (t []byte, ok bool) {
 			continue
 		}
 		rr, size := utf8.DecodeRune(s[r:])
-		if rr == utf8.RuneError && size == 1 {
+		if rr == utf8.RuneError {
 			break
 		}
 		r += size


### PR DESCRIPTION
Summary:
- Fuzz function looked like it was testing the same input twice, I changed that and a reserialization difference was found
- The test failed for the value `"\xbd\x00"` with "reserialized data does not match"; commit message has more details
- Fixed by quoting any invalid UTF-8 string and any string containing the literal `utf8.RuneError`
- Added decode checks on the key making the parser more strict on key input. I'd like some help here, the decode benchmark difference below doesn't seem to justify the edge case it covers
- Probably not ready to merge just yet

New tests results with existing code:

```
--- FAIL: TestDecoder_errors (0.00s)
	decode_test.go:145: got: <nil>, want: logfmt syntax error at pos 5 on line 1: invalid key
	decode_test.go:145: got: <nil>, want: logfmt syntax error at pos 2 on line 1: invalid key
--- FAIL: TestEncodeKeyval (0.00s)
	encode_test.go:71: "k", "\xbd": got 'k=�', want 'k="\ufffd"'
	encode_test.go:71: "k", "�\x00": got 'k="�\u0000"', want 'k="\ufffd\u0000"'
	encode_test.go:71: "k", "�": got 'k=�', want 'k="\ufffd"'
	encode_test.go:71: "k", []byte{0xef, 0xbf, 0xbd, 0x0}: got 'k="�\u0000"', want 'k="\ufffd\u0000"'
	encode_test.go:71: "k", []byte{0xef, 0xbf, 0xbd}: got 'k=�', want 'k="\ufffd"'
--- FAIL: TestMarshalKeyvals (0.00s)
	encode_test.go:135: []interface {}{"�"}: got error: <nil>, want error: invalid key
	encode_test.go:138: []interface {}{"�"}: got '�=null', want ''
	encode_test.go:135: []interface {}{"\xbd"}: got error: <nil>, want error: invalid key
	encode_test.go:138: []interface {}{"\xbd"}: got '�=null', want ''
```

Old benchmarks:

```
BenchmarkDecodeKeyval-8              500           2454245 ns/op         203.73 MB/s
BenchmarkKRDecode-8                  500           2332233 ns/op         214.39 MB/s
BenchmarkEncodeKeyval-8          2000000               704 ns/op              64 B/op          4 allocs/op
```

New benchmarks:

```
BenchmarkDecodeKeyval-8              500           3694369 ns/op         135.34 MB/s
BenchmarkKRDecode-8                 1000           2369236 ns/op         211.04 MB/s
BenchmarkEncodeKeyval-8          2000000               716 ns/op              64 B/op          4 allocs/op
```