### PR TITLE
Allow single quotes for values

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -52,6 +52,7 @@ func (dec *Decoder) ScanRecord() bool {
 // returns false when decoding stops, either by reaching the end of the
 // current record or an error.
 func (dec *Decoder) ScanKeyval() bool {
+	var qChar byte
 	dec.key, dec.value = nil, nil
 	if dec.err != nil {
 		return false
@@ -89,7 +90,7 @@ key:
 				return false
 			}
 			goto equal
-		case c == '"':
+		case c == '"' || c == '\'':
 			dec.pos += p
 			dec.unexpectedByte(c)
 			return false
@@ -125,7 +126,8 @@ equal:
 	switch c := line[dec.pos]; {
 	case c <= ' ':
 		return true
-	case c == '"':
+	case c == '"' || c == '\'':
+		qChar = c
 		goto qvalue
 	}
 
@@ -133,7 +135,7 @@ equal:
 	start = dec.pos
 	for p, c := range line[dec.pos:] {
 		switch {
-		case c == '=' || c == '"':
+		case c == '=' || c == '"' || c == '\'':
 			dec.pos += p
 			dec.unexpectedByte(c)
 			return false
@@ -163,9 +165,9 @@ qvalue:
 		switch {
 		case esc:
 			esc = false
-		case c == '\\':
+		case c == '\\' && qChar == '"':
 			hasEsc, esc = true, true
-		case c == '"':
+		case c == qChar:
 			dec.pos += p + 2
 			if hasEsc {
 				v, ok := unquoteBytes(line[start:dec.pos])
@@ -181,6 +183,7 @@ qvalue:
 					dec.value = line[start:end]
 				}
 			}
+			qChar = 0
 			return true
 		}
 	}

--- a/decode.go
+++ b/decode.go
@@ -165,7 +165,7 @@ qvalue:
 		switch {
 		case esc:
 			esc = false
-		case c == '\\' && qChar == '"':
+		case c == '\\':
 			hasEsc, esc = true, true
 		case c == qChar:
 			dec.pos += p + 2

--- a/decode_test.go
+++ b/decode_test.go
@@ -28,7 +28,9 @@ func TestDecoder_scan(t *testing.T) {
 		{`y`, [][]kv{{{[]byte("y"), nil}}}},
 		{`y=f`, [][]kv{{{[]byte("y"), []byte("f")}}}},
 		{"y=\"\\tf\"", [][]kv{{{[]byte("y"), []byte("\tf")}}}},
+		{"y=\"\\\"f\\\"\"", [][]kv{{{[]byte("y"), []byte("\"f\"")}}}},
 		{"y='t\tf'", [][]kv{{{[]byte("y"), []byte("t\tf")}}}},
+		{"y='\\'f\\''", [][]kv{{{[]byte("y"), []byte("'f'")}}}},
 		{"a=1\n", [][]kv{{{[]byte("a"), []byte("1")}}}},
 		{
 			`a=1 b="bar" ƒ=2h3s r="esc\t" d x=sf   `,

--- a/decode_test.go
+++ b/decode_test.go
@@ -28,6 +28,7 @@ func TestDecoder_scan(t *testing.T) {
 		{`y`, [][]kv{{{[]byte("y"), nil}}}},
 		{`y=f`, [][]kv{{{[]byte("y"), []byte("f")}}}},
 		{"y=\"\\tf\"", [][]kv{{{[]byte("y"), []byte("\tf")}}}},
+		{"y='t\tf'", [][]kv{{{[]byte("y"), []byte("t\tf")}}}},
 		{"a=1\n", [][]kv{{{[]byte("a"), []byte("1")}}}},
 		{
 			`a=1 b="bar" ƒ=2h3s r="esc\t" d x=sf   `,

--- a/jsonstring.go
+++ b/jsonstring.go
@@ -163,7 +163,7 @@ func getu4(s []byte) rune {
 }
 
 func unquoteBytes(s []byte) (t []byte, ok bool) {
-	if len(s) < 2 || s[0] != '"' || s[len(s)-1] != '"' {
+	if len(s) < 2 || (s[0] != '"' && s[0] != '\'') || (s[len(s)-1] != '"' && s[len(s)-1] != '\'') {
 		return
 	}
 	s = s[1 : len(s)-1]


### PR DESCRIPTION
While not strictly part of the non-standard that is logfmt, wrapping values in single quotes is a thing 
that can happen since many developers think of them as fairly interchangeable.

This adds supports for decoding this values, but *does not* add support of encoding, following the [Robustness principle](https://en.wikipedia.org/wiki/Robustness_principle)