### PR TITLE
On panic while printing, attempt to print panic value

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -278,7 +278,7 @@ func safeError(err error) (s string, ok bool) {
 			if v := reflect.ValueOf(err); v.Kind() == reflect.Ptr && v.IsNil() {
 				s, ok = "null", false
 			} else {
-				panic(panicVal)
+				s, ok = fmt.Sprintf("PANIC:%v", panicVal), false
 			}
 		}
 	}()
@@ -292,7 +292,7 @@ func safeString(str fmt.Stringer) (s string, ok bool) {
 			if v := reflect.ValueOf(str); v.Kind() == reflect.Ptr && v.IsNil() {
 				s, ok = "null", false
 			} else {
-				panic(panicVal)
+				s, ok = fmt.Sprintf("PANIC:%v", panicVal), true
 			}
 		}
 	}()
@@ -306,7 +306,7 @@ func safeMarshal(tm encoding.TextMarshaler) (b []byte, err error) {
 			if v := reflect.ValueOf(tm); v.Kind() == reflect.Ptr && v.IsNil() {
 				b, err = nil, nil
 			} else {
-				panic(panicVal)
+				b, err = nil, fmt.Errorf("panic when marshalling: %s", panicVal)
 			}
 		}
 	}()


### PR DESCRIPTION
Fixes #6 

Note the three variants are all different - I chose to reduce cascading changes.
* An `ok=false` return from `safeString` is unilaterally used by `writeKey` to conclude that the key was `nil`, so I went with `ok=true` there.
* `safeError` does not have this issue so I went with `ok=false` because, well, a panic isn't ok.
* `safeMarshal` returns an error if the underlying marshal errored, so I decided a panic is a kind of error. 