### PR TITLE
Fewer errors

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -110,8 +110,8 @@ func (e *MarshalerError) Error() string {
 // a nil interface or pointer value.
 var ErrNilKey = errors.New("nil key")
 
-// ErrInvalidKey is returned by Marshal functions and Encoder methods if a key
-// contains an invalid character.
+// ErrInvalidKey is returned by Marshal functions and Encoder methods if, after
+// dropping invalid runes, a key is empty.
 var ErrInvalidKey = errors.New("invalid key")
 
 // ErrUnsupportedKeyType is returned by Encoder methods if a key has an
@@ -165,31 +165,32 @@ func writeKey(w io.Writer, key interface{}) error {
 	}
 }
 
-func invalidKeyRune(r rune) bool {
-	return r <= ' ' || r == '=' || r == '"' || r == utf8.RuneError
-}
-
-func invalidKeyString(key string) bool {
-	return len(key) == 0 || strings.IndexFunc(key, invalidKeyRune) != -1
-}
-
-func invalidKey(key []byte) bool {
-	return len(key) == 0 || bytes.IndexFunc(key, invalidKeyRune) != -1
+// keyRuneFilter returns r for all valid key runes, and -1 for all invalid key
+// runes. When used as the mapping function for strings.Map and bytes.Map
+// functions it causes them to remove invalid key runes from strings or byte
+// slices respectively.
+func keyRuneFilter(r rune) rune {
+	if r <= ' ' || r == '=' || r == '"' || r == utf8.RuneError {
+		return -1
+	}
+	return r
 }
 
 func writeStringKey(w io.Writer, key string) error {
-	if invalidKeyString(key) {
+	k := strings.Map(keyRuneFilter, key)
+	if k == "" {
 		return ErrInvalidKey
 	}
-	_, err := io.WriteString(w, key)
+	_, err := io.WriteString(w, k)
 	return err
 }
 
 func writeBytesKey(w io.Writer, key []byte) error {
-	if invalidKey(key) {
+	k := bytes.Map(keyRuneFilter, key)
+	if len(k) == 0 {
 		return ErrInvalidKey
 	}
-	_, err := w.Write(key)
+	_, err := w.Write(k)
 	return err
 }
 


### PR DESCRIPTION
Experience has shown that including invalid runes (especially spaces) in
keys is the most common mistake when encoding. Returning an error for keys
containing invalid runes is not helpful because log packages often discard
the field or entire record when there is an encoding error. But missing
log data surprises application developers that don't understand why it
was discarded.

I considered two ways to handle bad runes in keys, optionally replacing
them with a different configurable rune, or dropping the bad runes from
they key. The first approach requires expanding the API and adding some
complexity to the implementation of Encoder. The second choice does not
change the API and, thanks to the `strings.Map` and `bytes.Map functions`,
slightly simplifies the implementation; so I chose it.